### PR TITLE
Fix of unicode issue with url passed to urllib2

### DIFF
--- a/mktplace/mktplace_communication.py
+++ b/mktplace/mktplace_communication.py
@@ -40,7 +40,7 @@ class MarketPlaceCommunication(object):
     GET_HEADER = {"Accept": "application/cbor"}
 
     def __init__(self, baseurl):
-        self.BaseURL = baseurl.rstrip('/')
+        self.BaseURL = baseurl.rstrip('/').encode('utf-8')
         self.ProxyHandler = urllib2.ProxyHandler({})
 
     def headrequest(self, path):


### PR DESCRIPTION
Prior changes to allow unicode LedgerURL and other configs caused urllib2 to error when using the url to open a connection. This caused the mktclient to report that there was "no response from server" while the error was a UnicodeDecodeError.

This change encodes the either unicode or str as a str using utf-8 in the __init__ method of MarketPlaceCommunication before its first use with urllib2.